### PR TITLE
Add version to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
 	"main": "index.js",
 	"name": "yasha",
+	"version": "0.0.0",
 	"dependencies": {
 		"discord.js": "^13.3.0",
 		"node-fetch": "^2.6.6",


### PR DESCRIPTION
Add version to the package.json.

The yarn package-manager will throw an error when installing this package because it does not have a version.

```
$ yarn add yasha@git+https://github.com/ilikdoge/yasha.git
yarn add v1.22.19
info No lockfile found.
[1/4] Resolving packages...
error Can't add "yasha": invalid package version undefined.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

[sange](https://github.com/ilikdoge/sange) also has this problem.