### PR TITLE
Updated Youtube.js documentation to include example cookie string

### DIFF
--- a/docs/Source.md
+++ b/docs/Source.md
@@ -87,6 +87,7 @@ const {Source: {Youtube}, Track: {TrackResults}} = require('yasha');
 Youtube.search(input: string): Promise<TrackResults>
 
 // account cookie for age verification
+// Example form: "__Secure-3PSID=COOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
 Youtube.setCookie(cookie: string): void
 ```
 

--- a/docs/Source.md
+++ b/docs/Source.md
@@ -88,6 +88,10 @@ Youtube.search(input: string): Promise<TrackResults>
 
 // account cookie for age verification
 // Example form: "__Secure-3PSID=COOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
+// To get COOKIE_CONTENT, go to youtube, press F12 to go to dev tools, 
+// click Application on Chrome or Storage on Firefox, go to Cookies, https://www.youtube.com, 
+// then go to both __Secure-3PSID and __Secure-3PAPISID, and copy the values.
+// Replace COOKIE_CONTENT in the Example form with the respective values.
 Youtube.setCookie(cookie: string): void
 ```
 

--- a/docs/Source.md
+++ b/docs/Source.md
@@ -87,11 +87,11 @@ const {Source: {Youtube}, Track: {TrackResults}} = require('yasha');
 Youtube.search(input: string): Promise<TrackResults>
 
 // account cookie for age verification
-// Example form: "__Secure-3PSID=COOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
-// To get COOKIE_CONTENT, go to youtube, press F12 to go to dev tools, 
-// click Application on Chrome or Storage on Firefox, go to Cookies, https://www.youtube.com, 
+// Example form: "__Secure-3PSID=SECRET1; __Secure-3PAPISID=SECRET2"
+// To get the secrets, go to youtube, press F12 to go to dev tools,
+// click Application on Chrome or Storage on Firefox, go to Cookies, https://www.youtube.com,
 // then go to both __Secure-3PSID and __Secure-3PAPISID, and copy the values.
-// Replace COOKIE_CONTENT in the Example form with the respective values.
+// Replace corresponding values in the example form with the respective values.
 Youtube.setCookie(cookie: string): void
 ```
 

--- a/src/api/Youtube.js
+++ b/src/api/Youtube.js
@@ -438,6 +438,11 @@ const api = new class YoutubeAPI{
 	}
 
 	//Example form: "__Secure-3PSID=COOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
+	// Example form: "__Secure-3PSID=COOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
+	// To get COOKIE_CONTENT, go to youtube, press F12 to go to dev tools, 
+	// click Application on Chrome or Storage on Firefox, go to Cookies, https://www.youtube.com, 
+	// then go to both __Secure-3PSID and __Secure-3PAPISID, and copy the values.
+	// Replace both COOKIE_CONTENT in the Example form with the respective values.
 	set_cookie(cookiestr){
 		if(!cookiestr){
 			this.cookie = '';

--- a/src/api/Youtube.js
+++ b/src/api/Youtube.js
@@ -437,7 +437,6 @@ const api = new class YoutubeAPI{
 		return results;
 	}
 
-	//Example form: "__Secure-3PSID=COOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
 	// Example form: "__Secure-3PSID=COOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
 	// To get COOKIE_CONTENT, go to youtube, press F12 to go to dev tools, 
 	// click Application on Chrome or Storage on Firefox, go to Cookies, https://www.youtube.com, 

--- a/src/api/Youtube.js
+++ b/src/api/Youtube.js
@@ -437,7 +437,7 @@ const api = new class YoutubeAPI{
 		return results;
 	}
 
-	//Example form: "__Secure-3PSID=cOOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
+	//Example form: "__Secure-3PSID=COOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
 	set_cookie(cookiestr){
 		if(!cookiestr){
 			this.cookie = '';

--- a/src/api/Youtube.js
+++ b/src/api/Youtube.js
@@ -437,11 +437,6 @@ const api = new class YoutubeAPI{
 		return results;
 	}
 
-	// Example form: "__Secure-3PSID=COOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
-	// To get COOKIE_CONTENT, go to youtube, press F12 to go to dev tools, 
-	// click Application on Chrome or Storage on Firefox, go to Cookies, https://www.youtube.com, 
-	// then go to both __Secure-3PSID and __Secure-3PAPISID, and copy the values.
-	// Replace both COOKIE_CONTENT in the Example form with the respective values.
 	set_cookie(cookiestr){
 		if(!cookiestr){
 			this.cookie = '';

--- a/src/api/Youtube.js
+++ b/src/api/Youtube.js
@@ -437,6 +437,7 @@ const api = new class YoutubeAPI{
 		return results;
 	}
 
+	//Example form: "__Secure-3PSID=cOOKIE_CONTENT;__Secure-3PAPISID=COOKIE_CONTENT"
 	set_cookie(cookiestr){
 		if(!cookiestr){
 			this.cookie = '';


### PR DESCRIPTION
It took me a while to figure out how to format the string so Youtube would accept it, so I added an example string to the documentation.