### PR TITLE
Remove var

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ Example usage
 ```js
 // designed to work with discord.js v13+ and uses discordjs/voice internally for voice connections
 
-var connection = await VoiceConnection.connect(voiceChannel); // see docs/VoiceConnection.md
-var player = new TrackPlayer(); // see docs/TrackPlayer.md
+const connection = await VoiceConnection.connect(voiceChannel); // see docs/VoiceConnection.md
+const player = new TrackPlayer(); // see docs/TrackPlayer.md
 
-var track = await Source.resolve('https://www.youtube.com/watch?v=dQw4w9WgXcQ'); // see docs/Source.md
+const track = await Source.resolve('https://www.youtube.com/watch?v=dQw4w9WgXcQ'); // see docs/Source.md
 
 connection.subscribe(player);
 player.play(track);
@@ -60,13 +60,13 @@ client.on('ready', () => {
 client.on('messageCreate', async (message) => {
 	if(message.content == 'play a song!'){
 		// see docs/VoiceConnection.md
-		var connection = await VoiceConnection.connect(message.member.voice.channel);
+		const connection = await VoiceConnection.connect(message.member.voice.channel);
 
 		// see docs/TrackPlayer.md
-		var player = new TrackPlayer();
+		const player = new TrackPlayer();
 
 		// see docs/Source.md
-		var track = await Source.resolve('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+		const track = await Source.resolve('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
 
 		connection.subscribe(player);
 		player.play(track);

--- a/docs/FileTrack.md
+++ b/docs/FileTrack.md
@@ -10,13 +10,13 @@ Returns a track if the string is a valid http(s) or file URL, otherwise `null`
 ```js
 const {Source} = require('yasha');
 
-var track = await Source.File.resolve('https://www.example.com/audio.mp4');
+const track1 = await Source.File.resolve('https://www.example.com/audio.mp4');
 
-assert(track.isLocalFile == false);
+assert(track1.isLocalFile == false);
 
-var track = await Source.File.resolve('file:///path/to/your/file');
+const track2 = await Source.File.resolve('file:///path/to/your/file');
 
-assert(track.isLocalFile == true);
+assert(track2.isLocalFile == true);
 
 ```
 
@@ -25,5 +25,5 @@ Create a new file track
 ```js
 const {Source} = require('yasha');
 
-var track = new Source.File.Track('https://www.example.com/audio.mp4');
+const track = new Source.File.Track('https://www.example.com/audio.mp4');
 ```

--- a/docs/Source.md
+++ b/docs/Source.md
@@ -7,22 +7,22 @@ Resolves a track from a string
 ```js
 const {Source} = require('yasha');
 
-var track = await Source.resolve('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+const track = await Source.resolve('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
 ```
 
 ```js
 const {Source, Track: {TrackPlaylist}} = require('yasha');
 
-var playlist = await Source.resolve('https://www.youtube.com/playlist?list=yourPLAYLISTidHERE');
+const playlist = await Source.resolve('https://www.youtube.com/playlist?list=yourPLAYLISTidHERE');
 
 console.log(playlist instanceof TrackPlaylist); // true
 ```
 
 ```js
-var result = await Source.resolve(input);
+const result = await Source.resolve(input);
 
 if(result instanceof TrackPlaylist){
-	var list = await result.load();
+	const list = await result.load();
 
 	console.log(`Loaded ${list.length} tracks`);
 
@@ -31,14 +31,14 @@ if(result instanceof TrackPlaylist){
 	// aka offset = 0 or continuation = null or resolved from Source
 	console.log(`Found playlist ${result.title} ${result.url}`);
 
-	var first_track = result.firstTrack;
-	var list: Track[] = [];
+	const first_track = result.firstTrack;
+	let list: Track[] = [];
 
 	if(first_track)
 		list.push(first_track);
 	while(result && result.length){
 		if(first_track){
-			for(var i = 0; i < result.length; i++){
+			for(let i = 0; i < result.length; i++){
 				if(result[i].equals(first_track)){
 					result.splice(i, 1);
 					first_track = null;

--- a/docs/TrackPlayer.md
+++ b/docs/TrackPlayer.md
@@ -7,11 +7,11 @@ Plays a track to a voice connection
 ```js
 const {TrackPlayer, VoiceConnection, Source} = require('yasha');
 
-var player = new TrackPlayer();
-var track = await Source.resolve('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
-var connection = await VoiceConnection.connect(channel);
+const player = new TrackPlayer();
+const track = await Source.resolve('https://www.youtube.com/watch?v=dQw4w9WgXcQ');
+const connection = await VoiceConnection.connect(channel);
 
-var subscription = connection.subscribe(player);
+const subscription = connection.subscribe(player);
 
 player.play(track);
 player.start();
@@ -27,7 +27,7 @@ class TrackPlayerOptions{
 	external_packet_send: boolean // Use native code to send audio packets to the voice connection. external_encrypt must be enabled
 }
 
-var player = new TrackPlayer(new TrackPlayerOptions());
+const player = new TrackPlayer(new TrackPlayerOptions());
 ```
 
 #### Events

--- a/docs/VoiceConnection.md
+++ b/docs/VoiceConnection.md
@@ -48,8 +48,8 @@ Subscribe (see @discordjs/voice subscribe documentation)
 ```js
 const {TrackPlayer} = require('yasha');
 
-var player = new TrackPlayer();
-var subscription = connection.subscribe(player);
+const player = new TrackPlayer();
+const subscription = connection.subscribe(player);
 ```
 
 Unubscribe
@@ -62,7 +62,7 @@ Rejoin
 ```js
 const {VoiceChannel} = require('discord.js');
 
-var connection = await VoiceConnection.connect(...);
+const connection = await VoiceConnection.connect(...);
 
 connection.rejoin(channel: VoiceChannel): void
 ```
@@ -70,7 +70,7 @@ connection.rejoin(channel: VoiceChannel): void
 Disconnect/Destroy
 
 ```js
-var connection = await VoiceConnection.connect(...);
+const connection = await VoiceConnection.connect(...);
 
 connection.disconnect(): void // alias for destroy
 connection.destroy(): void
@@ -79,7 +79,7 @@ connection.destroy(): void
 Ready
 
 ```js
-var connection = await VoiceConnection.connect(...);
+const connection = await VoiceConnection.connect(...);
 
 connection.ready(): boolean; // whether the connection is ready
 ```

--- a/proto/youtube.js
+++ b/proto/youtube.js
@@ -25,28 +25,28 @@ function b64url_to_binary(input){
 
 module.exports = {
 	playlist_next_offset(continuation){
-		var p = playlist.deserializeBinary(b64url_to_binary(continuation));
-		var cont = p.getContinuation();
+		const p = playlist.deserializeBinary(b64url_to_binary(continuation));
+		const cont = p.getContinuation();
 
 		if(!cont)
 			return undefined;
-		var params = cont.getParams();
+		let params = cont.getParams();
 
 		if(!params)
 			return undefined;
 		params = playlist_params.deserializeBinary(b64url_to_binary(params));
 
-		var offset = params.getOffset();
+		const offset = params.getOffset();
 
 		if(!offset)
 			return undefined;
-		var p_offset = playlist_offset.deserializeBinary(b64url_to_binary(offset.substring('PT:'.length)));
+		const p_offset = playlist_offset.deserializeBinary(b64url_to_binary(offset.substring('PT:'.length)));
 
 		return p_offset.getOffset();
 	},
 
 	gen_playlist_continuation(id, offset){
-		var p_offset = new playlist_offset(), p_params = new playlist_params(),
+		const p_offset = new playlist_offset(), p_params = new playlist_params(),
 			p_cont = new playlist.playlist_continuation(), p = new playlist();
 		p_offset.setOffset(offset);
 		p_params.setPage(Math.floor(offset / 100));
@@ -61,7 +61,7 @@ module.exports = {
 	},
 
 	gen_search_continuation(query, offset, options){
-		var s_cont = new search_continuation(),
+		const s_cont = new search_continuation(),
 			s_data = new search_continuation.search_data(),
 			s_filters = new search_filters(),
 			s_options = new search_options(),
@@ -85,7 +85,7 @@ module.exports = {
 	},
 
 	gen_search_options(opts){
-		var options = new search(),
+		const options = new search(),
 			filters = new search_filters();
 		switch(opts.sort){
 			case 'relevance':

--- a/src/Request.js
+++ b/src/Request.js
@@ -11,7 +11,7 @@ async function fetch(url, opts = {}){
 
 module.exports = new class{
 	async getResponse(url, options){
-		var res;
+		let res;
 
 		try{
 			res = await fetch(url, options);
@@ -25,7 +25,7 @@ module.exports = new class{
 	async get(url, options){
 		const {res} = await this.getResponse(url, options);
 
-		var body;
+		let body;
 
 		try{
 			body = await res.text();
@@ -55,7 +55,7 @@ module.exports = new class{
 	async getBuffer(url, options){
 		const {res} = await this.getResponse(url, options);
 
-		var body;
+		let body;
 
 		try{
 			body = await res.buffer();

--- a/src/Source.js
+++ b/src/Source.js
@@ -63,7 +63,7 @@ const youtube = new class Youtube extends APISource{
 	}
 
 	match(content){
-		var url;
+		let url;
 
 		try{
 			url = new URL(content);
@@ -71,13 +71,13 @@ const youtube = new class Youtube extends APISource{
 			return null;
 		}
 
-		var id = null, list = null;
+		let id = null, list = null;
 
 		if(url.hostname == 'youtu.be')
 			id = url.pathname.substring(1);
 		else if((url.hostname == 'www.youtube.com' || url.hostname == 'music.youtube.com' || url.hostname == 'youtube.com') && url.pathname == '/watch')
 			id = url.searchParams.get('v');
-		var match = this.weak_match(id);
+		let match = this.weak_match(id);
 
 		list = url.searchParams.get('list');
 
@@ -91,13 +91,13 @@ const youtube = new class Youtube extends APISource{
 	}
 
 	async resolve(match){
-		var track = null, list = null;
+		let track = null, list = null;
 
 		if(match.id)
 			track = this.api.get(match.id);
 		if(match.list)
 			list = this.api.playlist_once(match.list);
-		var result = await Promise.allSettled([track, list]);
+		const result = await Promise.allSettled([track, list]);
 
 		track = result[0].value;
 		list = result[1].value;
@@ -140,7 +140,7 @@ const soundcloud = new class Soundcloud extends APISource{
 	}
 
 	match(content){
-		var url;
+		let url;
 
 		try{
 			url = new URL(content);
@@ -185,7 +185,7 @@ const spotify = new class Spotify extends APISource{
 	}
 
 	match(content){
-		var url;
+		let url;
 
 		try{
 			url = new URL(content);
@@ -194,7 +194,7 @@ const spotify = new class Spotify extends APISource{
 		}
 
 		if(url.hostname == 'open.spotify.com' && url.pathname.startsWith('/') && url.pathname.length > 1){
-			var data = url.pathname.substring(1).split('/');
+			const data = url.pathname.substring(1).split('/');
 
 			if(data.length != 2)
 				return null;
@@ -243,7 +243,7 @@ const apple = new class AppleMusic extends APISource{
 	}
 
 	match(content){
-		var url;
+		let url;
 
 		try{
 			url = new URL(content);
@@ -252,7 +252,7 @@ const apple = new class AppleMusic extends APISource{
 		}
 
 		if(url.hostname == 'music.apple.com' && url.pathname.startsWith('/') && url.pathname.length > 1){
-			var path = url.pathname.substring(1).split('/');
+			const path = url.pathname.substring(1).split('/');
 
 			if(path.length < 2)
 				return null;
@@ -266,7 +266,7 @@ const apple = new class AppleMusic extends APISource{
 				case 'playlist':
 					return {playlist: path[2] ?? path[1]};
 				case 'album':
-					var track = url.searchParams.get('i');
+					const track = url.searchParams.get('i');
 
 					if(track)
 						return {track};
@@ -305,7 +305,7 @@ const file = new class File extends APISource{
 	}
 
 	resolve(content){
-		var url;
+		let url;
 
 		try{
 			url = new URL(content);
@@ -323,15 +323,15 @@ const file = new class File extends APISource{
 
 class Source{
 	static resolve(input, weak = true){
-		var sources = [youtube, soundcloud, spotify, apple];
-		var match = null;
+		const sources = [youtube, soundcloud, spotify, apple];
+		let match = null;
 
-		for(var source of sources)
+		for(const source of sources)
 			if(match = source.match(input))
 				return source.resolve(match);
 		if(!weak)
 			return null;
-		for(var source of sources)
+		for(const source of sources)
 			if(match = source.weak_match(input))
 				return source.weak_resolve(match);
 		return null;

--- a/src/Track.js
+++ b/src/Track.js
@@ -137,7 +137,7 @@ class TrackPlaylist extends TrackResults{
 	}
 
 	async load(){
-		var result;
+		let result;
 
 		result = await this.next();
 
@@ -148,7 +148,7 @@ class TrackPlaylist extends TrackResults{
 		}
 
 		if(this.firstTrack){
-			var index = this.findIndex(track => track.equals(this.firstTrack));
+			const index = this.findIndex(track => track.equals(this.firstTrack));
 
 			if(index == -1)
 				this.unshift(this.firstTrack);
@@ -174,7 +174,7 @@ class TrackImage{
 	static from(array){
 		if(!array)
 			return [];
-		for(var i = 0; i < array.length; i++)
+		for(let i = 0; i < array.length; i++)
 			array[i] = new TrackImage(array[i].url, array[i].width, array[i].height);
 		return array;
 	}

--- a/src/TrackPlayer.js
+++ b/src/TrackPlayer.js
@@ -80,7 +80,7 @@ class TrackPlayer extends EventEmitter{
 			connection.on('stateChange', this.onstatechange);
 		}
 
-		var subscription = new Subscription(connection, this);
+		const subscription = new Subscription(connection, this);
 
 		this.subscriptions.push(subscription);
 
@@ -90,7 +90,7 @@ class TrackPlayer extends EventEmitter{
 	}
 
 	unsubscribe(subscription){
-		var index = this.subscriptions.indexOf(subscription);
+		const index = this.subscriptions.indexOf(subscription);
 
 		if(index == -1)
 			return;
@@ -150,9 +150,9 @@ class TrackPlayer extends EventEmitter{
 		if(!this.external_encrypt || !this.player)
 			return;
 		if(this.secretbox_ready()){
-			var connection_data = this.get_connection_data(),
+			const connection_data = this.get_connection_data(),
 				udp = this.get_connection_udp();
-			var mode;
+			let mode;
 
 			switch(connection_data.encryptionMode){
 				case 'xsalsa20_poly1305_lite':
@@ -169,7 +169,7 @@ class TrackPlayer extends EventEmitter{
 					break;
 			}
 
-			var data = this.get_connection_data();
+			const data = this.get_connection_data();
 
 			try{
 				this.player.ffplayer.setSecretBox(connection_data.secretKey, mode, connection_data.ssrc);
@@ -230,7 +230,7 @@ class TrackPlayer extends EventEmitter{
 	}
 
 	async load_streams(){
-		var streams, play_id = this.play_id;
+		let streams, play_id = this.play_id;
 
 		if(this.track.streams && !this.track.streams.expired())
 			streams = this.track.streams;
@@ -273,16 +273,16 @@ class TrackPlayer extends EventEmitter{
 	}
 
 	send(buffer, frame_size, is_silence){
-		var subscriptions = this.subscriptions, connection;
+		const subscriptions = this.subscriptions, connection;
 
-		for(var i = 0; i < subscriptions.length; i++){
+		for(let i = 0; i < subscriptions.length; i++){
 			connection = subscriptions[i].connection;
 
 			if(!connection.ready())
 				continue;
 			connection.setSpeaking(true);
 
-			var state = connection.state.networking.state,
+			const state = connection.state.networking.state,
 				connection_data = state.connectionData,
 				mode = connection_data.encryption_mode;
 			if(this.external_encrypt && !is_silence){
@@ -321,7 +321,7 @@ class TrackPlayer extends EventEmitter{
 			audio_buffer.writeUIntBE(connection_data.timestamp, 4, 4);
 			audio_buffer.writeUIntBE(connection_data.ssrc, 8, 4);
 
-			var len, buf;
+			let len, buf;
 
 			switch(mode){
 				case EncryptionMode.LITE:
@@ -362,7 +362,7 @@ class TrackPlayer extends EventEmitter{
 
 		if(this.player && this.external_encrypt && this.secretbox_ready()){
 			/* restore modified secretbox state from the player */
-			var box = this.player.ffplayer.getSecretBox(),
+			const box = this.player.ffplayer.getSecretBox(),
 				data = this.get_connection_data();
 			data.nonce = box.nonce;
 			data.timestamp = box.timestamp;
@@ -376,7 +376,7 @@ class TrackPlayer extends EventEmitter{
 
 			if(this.player && this.external_encrypt && this.secretbox_ready()){
 				/* save modified secretbox state to the player */
-				var data = this.get_connection_data();
+				const data = this.get_connection_data();
 
 				this.player.ffplayer.updateSecretBox(data.sequence, data.timestamp, data.nonce);
 			}
@@ -416,9 +416,9 @@ class TrackPlayer extends EventEmitter{
 	}
 
 	get_best_stream_one(streams){
-		var opus = [], audio = [], other = [];
+		const opus = [], audio = [], other = [];
 
-		for(var stream of streams){
+		for(const stream of streams){
 			if(stream.video){
 				other.push(stream);
 
@@ -445,7 +445,7 @@ class TrackPlayer extends EventEmitter{
 	}
 
 	get_best_stream(streams){
-		var result, volume = streams.volume;
+		let result, volume = streams.volume;
 
 		streams = streams.filter((stream) => stream.audio);
 		result = this.get_best_stream_one(streams.filter((stream) => stream.default_audio_track))

--- a/src/VoiceConnection.js
+++ b/src/VoiceConnection.js
@@ -165,7 +165,7 @@ class VoiceConnection extends voice.VoiceConnection{
 	static async connect(channel, options = {}){
 		if(!channel.joinable)
 			throw new Error(channel.full ? 'Channel is full' : 'No permissions');
-		var connection = channel.guild.voice_connection;
+		let connection = channel.guild.voice_connection;
 
 		if(!connection)
 			connection = new VoiceConnection(channel, options);
@@ -193,9 +193,9 @@ class VoiceConnection extends voice.VoiceConnection{
 
 		if(!guild.me.voice.channel)
 			return false;
-		var {rejoin, disconnect} = voice.VoiceConnection.prototype;
+		const {rejoin, disconnect} = voice.VoiceConnection.prototype;
 
-		var dummy = {
+		const dummy = {
 			state: {
 				status: VoiceConnectionStatus.ready,
 				adapter: guild.voiceAdapterCreator({

--- a/src/api/AppleMusic.js
+++ b/src/api/AppleMusic.js
@@ -10,15 +10,15 @@ class AppleMusicTrack extends Track{
 	}
 
 	gen_image(url, artist){
-		var dim = artist ? 220 : 486;
+		const dim = artist ? 220 : 486;
 
 		return [new TrackImage(url.replaceAll('{w}', dim).replaceAll('{h}', dim).replaceAll('{c}', artist ? 'sr' : 'bb').replaceAll('{f}', 'webp'), dim, dim)];
 	}
 
 	from(track){
-		var icon;
+		let icon;
 
-		for(var artist of track.relationships.artists.data)
+		for(const artist of track.relationships.artists.data)
 			if(artist.attributes.artwork)
 				icon = this.gen_image(artist.attributes.artwork.url, true);
 		this.artists = track.relationships.artists.data.map(artist => artist.attributes.name);
@@ -108,8 +108,8 @@ const api = (new class AppleMusicAPI{
 	}
 
 	async load(){
-		var {body} = await Request.get('https://music.apple.com/us/browse');
-		var config = /<meta name="desktop-music-app\/config\/environment" content="(.*?)">/.exec(body);
+		const {body} = await Request.get('https://music.apple.com/us/browse');
+		let config = /<meta name="desktop-music-app\/config\/environment" content="(.*?)">/.exec(body);
 
 		if(!config)
 			throw new SourceError.INTERNAL_ERROR(null, new Error('Missing config'));
@@ -132,9 +132,9 @@ const api = (new class AppleMusicAPI{
 	}
 
 	async api_request(path, query = {}, options = {}){
-		var res, body, queries = [];
+		let res, body, queries = [];
 
-		for(var name in query)
+		for(const name in query)
 			queries.push(encodeURIComponent(name) + '=' + encodeURIComponent(query[name]));
 		if(queries.length)
 			queries = '?' + queries.join('&');
@@ -142,7 +142,7 @@ const api = (new class AppleMusicAPI{
 			queries = '';
 		if(!options.headers)
 			options.headers = {};
-		for(var tries = 0; tries < 2; tries++){
+		for(let tries = 0; tries < 2; tries++){
 			await this.prefetch();
 
 			options.headers.authorization = `Bearer ${this.token}`;
@@ -189,7 +189,7 @@ const api = (new class AppleMusicAPI{
 	async get(id){
 		this.check_valid_id(id);
 
-		var track = await this.api_request('songs/' + id, {
+		const track = await this.api_request('songs/' + id, {
 			'fields[artists]': 'url,name,artwork,hero',
 			'include[songs]': 'artists',
 			'extend': 'artistUrl',
@@ -208,7 +208,7 @@ const api = (new class AppleMusicAPI{
 	}
 
 	get_next(url, param){
-		var num;
+		let num;
 
 		url = new URL(url, 'https://amp-api.music.apple.com');
 		num = parseInt(url.searchParams.get(param));
@@ -219,7 +219,7 @@ const api = (new class AppleMusicAPI{
 	}
 
 	async search(query, offset = 0, limit = 25){
-		var data = await this.api_request('search', {
+		const data = await this.api_request('search', {
 			groups: 'song',
 			offset,
 			limit,
@@ -239,15 +239,15 @@ const api = (new class AppleMusicAPI{
 			'omit[resource]': 'autos'
 		});
 
-		var results = new AppleMusicResults();
-		var song = data.results.song;
+		const results = new AppleMusicResults();
+		const song = data.results.song;
 
 		if(!song)
 			return results;
 		try{
 			if(song.next)
 				results.set_continuation(query, this.get_next(song.next, 'offset'));
-			for(var result of song.data)
+			for(const result of song.data)
 				results.push(new AppleMusicTrack().from(result));
 		}catch(e){
 			throw new SourceError.INTERNAL_ERROR(null, e);
@@ -259,8 +259,8 @@ const api = (new class AppleMusicAPI{
 	async list_once(type, id, offset = 0, limit = 100){
 		this.check_valid_playlist_id(id);
 
-		var result = new AppleMusicPlaylist();
-		var playlist;
+		const result = new AppleMusicPlaylist();
+		let playlist;
 
 		if(!offset){
 			playlist = await this. api_request(`${type}/${id}`, {
@@ -297,7 +297,7 @@ const api = (new class AppleMusicAPI{
 				playlist = playlist.relationships.tracks;
 			}
 
-			for(var item of playlist.data)
+			for(const item of playlist.data)
 				result.push(new AppleMusicTrack().from(item));
 			if(playlist.next)
 				result.set_continuation(this.get_next(playlist.next, 'offset'));
@@ -322,11 +322,11 @@ const api = (new class AppleMusicAPI{
 	}
 
 	async list(type, id, limit){
-		var list = null;
-		var offset = 0;
+		let list = null;
+		let offset = 0;
 
 		do{
-			var result = await this.list_once(type, id, offset);
+			const result = await this.list_once(type, id, offset);
 
 			if(!list)
 				list = result;

--- a/src/api/Soundcloud.js
+++ b/src/api/Soundcloud.js
@@ -12,7 +12,7 @@ class SoundcloudTrack extends Track{
 	from(track){
 		this.permalink_url = track.permalink_url;
 
-		var streams = new SoundcloudStreams().from(track);
+		const streams = new SoundcloudStreams().from(track);
 
 		if(streams.length)
 			this.setStreams(streams);
@@ -28,20 +28,20 @@ class SoundcloudTrack extends Track{
 	}
 
 	get_thumbnails(track){
-		var sizes = [20, 50, 120, 200, 500];
-		var visualSizes = [[1240, 260], [2480, 520]];
+		const sizes = [20, 50, 120, 200, 500];
+		const visualSizes = [[1240, 260], [2480, 520]];
 
-		var default_thumbnail = track.artwork_url || track.user.avatar_url;
-		var multires = /^.*\/(\w+)-([-a-zA-Z0-9]+)-([a-z0-9]+)\.(jpg|png|gif).*$/i.exec(default_thumbnail);
+		const default_thumbnail = track.artwork_url || track.user.avatar_url;
+		const multires = /^.*\/(\w+)-([-a-zA-Z0-9]+)-([a-z0-9]+)\.(jpg|png|gif).*$/i.exec(default_thumbnail);
 
-		var thumbnails = [];
+		const thumbnails = [];
 
 		if(multires){
-			var type = multires[1];
-			var size = multires[3];
+			const type = multires[1];
+			const size = multires[3];
 
 			if(type == 'visuals'){
-				for(var sz of visualSizes){
+				for(const sz of visualSizes){
 					thumbnails.push({
 						width: sz[0],
 						height: sz[1],
@@ -49,8 +49,8 @@ class SoundcloudTrack extends Track{
 					});
 				}
 			}else{
-				for(var sz of sizes){
-					var rep;
+				for(const sz of sizes){
+					let rep;
 
 					if(type == 'artworks' && sz == 20)
 						rep = 'tiny';
@@ -131,7 +131,7 @@ class SoundcloudStream extends TrackStream{
 	}
 
 	async getUrl(){
-		var body = await api.request(this.stream_url);
+		const body = await api.request(this.stream_url);
 
 		if(body && body.url)
 			return body.url;
@@ -150,8 +150,8 @@ class SoundcloudStreams extends TrackStreams{
 	}
 
 	extract_streams(streams){
-		for(var stream of streams){
-			var [match, container, codecs] = /audio\/([a-zA-Z0-9]{3,4})(?:;(?:\+| )?codecs="(.*?)")?/.exec(stream.format.mime_type);
+		for(const stream of streams){
+			let [match, container, codecs] = /audio\/([a-zA-Z0-9]{3,4})(?:;(?:\+| )?codecs="(.*?)")?/.exec(stream.format.mime_type);
 
 			if(container == 'mpeg' && !codecs)
 				codecs = 'mp3';
@@ -174,7 +174,7 @@ class SoundcloudStreams extends TrackStreams{
 	}
 }
 
-var api = new class SoundcloudAPI{
+const api = new class SoundcloudAPI{
 	constructor(){
 		this.client_id = null;
 		this.reloading = null;
@@ -202,13 +202,13 @@ var api = new class SoundcloudAPI{
 	}
 
 	async load(){
-		var {body} = await Request.get('https://soundcloud.com');
-		var regex = /<script crossorigin src="(.*?)"><\/script>/g;
-		var result;
+		const {body} = await Request.get('https://soundcloud.com');
+		const regex = /<script crossorigin src="(.*?)"><\/script>/g;
+		let result;
 
 		while(result = regex.exec(body)){
-			var script = (await Request.get(result[1])).body;
-			var id = /client_id:"([\w\d_-]+?)"/i.exec(script);
+			const script = (await Request.get(result[1])).body;
+			const id = /client_id:"([\w\d_-]+?)"/i.exec(script);
 
 			if(id && id[1]){
 				this.client_id = util.deepclone(id[1]);
@@ -221,15 +221,15 @@ var api = new class SoundcloudAPI{
 	}
 
 	async request(path, query = {}){
-		var res, body, queries = [];
+		let res, body, queries = [];
 
-		for(var tries = 0; tries < 2; tries++){
+		for(let tries = 0; tries < 2; tries++){
 			await this.prefetch();
 
 			query.client_id = this.client_id;
 			queries = [];
 
-			for(var name in query)
+			for(const name in query)
 				queries.push(name + '=' + query[name]);
 			res = (await Request.getResponse(path + '?' + queries.join('&'))).res;
 
@@ -270,8 +270,8 @@ var api = new class SoundcloudAPI{
 	}
 
 	async resolve_playlist(list, offset = 0, limit){
-		var unresolved_index = -1;
-		var tracks = new SoundcloudPlaylist();
+		let unresolved_index = -1;
+		const tracks = new SoundcloudPlaylist();
 
 		if(!list || typeof list != 'object' || !(list.tracks instanceof Array))
 			throw new SourceError.INTERNAL_ERROR(null, new Error('Invalid list'));
@@ -280,7 +280,7 @@ var api = new class SoundcloudAPI{
 		if(offset >= list.tracks.length)
 			return null;
 		try{
-			for(var i = offset; i < list.tracks.length; i++){
+			for(let i = offset; i < list.tracks.length; i++){
 				if(list.tracks[i].streamable === undefined){
 					unresolved_index = i;
 
@@ -298,13 +298,13 @@ var api = new class SoundcloudAPI{
 		else
 			limit += offset;
 		while(unresolved_index != -1 && unresolved_index < limit){
-			var ids = list.tracks.slice(unresolved_index, unresolved_index + 50);
-			var body = await this.api_request('tracks', {ids: ids.map(track => track.id).join(',')});
+			const ids = list.tracks.slice(unresolved_index, unresolved_index + 50);
+			const body = await this.api_request('tracks', {ids: ids.map(track => track.id).join(',')});
 
 			try{
 				if(!body.length)
 					break;
-				for(var track of body)
+				for(const track of body)
 					tracks.push(new SoundcloudTrack().from(track));
 			}catch(e){
 				throw new SourceError.INTERNAL_ERROR(null, e);
@@ -319,7 +319,7 @@ var api = new class SoundcloudAPI{
 	}
 
 	async resolve(url){
-		var body = await this.api_request('resolve', {url: encodeURIComponent(url)});
+		const body = await this.api_request('resolve', {url: encodeURIComponent(url)});
 
 		if(body.kind == 'track'){
 			try{
@@ -335,11 +335,11 @@ var api = new class SoundcloudAPI{
 	}
 
 	async resolve_shortlink(id){
-		var res, body, location, url;
+		let res, body, location, url;
 
 		url = 'https://on.soundcloud.com/' + encodeURIComponent(id);
 
-		for(var redirects = 0; redirects < 5; redirects++){
+		for(const redirects = 0; redirects < 5; redirects++){
 			res = (await Request.getResponse(url, {redirect: 'manual'})).res;
 
 			try{
@@ -379,9 +379,9 @@ var api = new class SoundcloudAPI{
 	async get(id){
 		this.check_valid_id(id);
 
-		var body = await this.api_request('tracks/' + id);
+		const body = await this.api_request('tracks/' + id);
 
-		var track;
+		let track;
 
 		try{
 			track = new SoundcloudTrack().from(body);
@@ -397,9 +397,9 @@ var api = new class SoundcloudAPI{
 	async get_streams(id){
 		this.check_valid_id(id);
 
-		var body = await this.api_request('tracks/' + id);
+		const body = await this.api_request('tracks/' + id);
 
-		var streams;
+		let streams;
 
 		try{
 			streams = new SoundcloudStreams().from(body);
@@ -413,12 +413,12 @@ var api = new class SoundcloudAPI{
 	}
 
 	async search(query, offset, limit = 20){
-		var body = await this.api_request('search/tracks', {q: encodeURIComponent(query), limit, offset});
+		const body = await this.api_request('search/tracks', {q: encodeURIComponent(query), limit, offset});
 
 		try{
-			var results = new SoundcloudResults();
+			const results = new SoundcloudResults();
 
-			for(var item of body.collection)
+			for(const item of body.collection)
 				results.push(new SoundcloudTrack().from(item));
 			if(body.collection.length)
 				results.set_continuation(query, offset + limit);
@@ -431,7 +431,7 @@ var api = new class SoundcloudAPI{
 	async playlist_once(id, offset = 0, limit = 50){
 		this.check_valid_id(id);
 
-		var body = await this.api_request('playlists/' + id);
+		const body = await this.api_request('playlists/' + id);
 
 		return this.resolve_playlist(body, offset, limit);
 	}

--- a/src/api/Spotify.js
+++ b/src/api/Spotify.js
@@ -98,7 +98,7 @@ const api = (new class SpotifyAPI{
 	}
 
 	async load(){
-		var {body} = await Request.getJSON('https://open.spotify.com/get_access_token?reason=transport&productType=web_player', {headers: this.account_data});
+		const {body} = await Request.getJSON('https://open.spotify.com/get_access_token?reason=transport&productType=web_player', {headers: this.account_data});
 
 		if(!body.accessToken)
 			throw new SourceError.INTERNAL_ERROR(null, new Error('Missing access token'));
@@ -117,9 +117,9 @@ const api = (new class SpotifyAPI{
 			options.headers = {};
 		if(options.body)
 			options.body = JSON.stringify(options.body);
-		var res, body;
+		let res, body;
 
-		for(var tries = 0; tries < 2; tries++){
+		for(let tries = 0; tries < 2; tries++){
 			await this.prefetch();
 
 			options.headers.authorization = 'Bearer ' + this.token;
@@ -163,12 +163,12 @@ const api = (new class SpotifyAPI{
 	async get(id){
 		this.check_valid_id(id);
 
-		var track = await this.api_request('tracks/' + id);
-		var author = track.artists[track.artists.length - 1];
+		const track = await this.api_request('tracks/' + id);
+		const author = track.artists[track.artists.length - 1];
 
 		if(!author)
 			throw new SourceError.INTERNAL_ERROR(null, new Error('Missing artist'));
-		var artist = await this.api_request('artists/' + author.id);
+		const artist = await this.api_request('artists/' + author.id);
 
 		try{
 			return new SpotifyTrack().from(track, artist);
@@ -182,13 +182,13 @@ const api = (new class SpotifyAPI{
 	}
 
 	async search(query, start = 0, length = 20){
-		var data = await this.api_request('search/?type=track&q=' + encodeURIComponent(query) + '&decorate_restrictions=false&include_external=audio&limit=' + length + '&offset=' + start);
-		var results = new SpotifyResults();
+		const data = await this.api_request('search/?type=track&q=' + encodeURIComponent(query) + '&decorate_restrictions=false&include_external=audio&limit=' + length + '&offset=' + start);
+		const results = new SpotifyResults();
 
 		if(data.tracks.items.length)
 			results.set_continuation(query, start + data.tracks.items.length);
 		try{
-			for(var result of data.tracks.items)
+			for(const result of data.tracks.items)
 				results.push(new SpotifyTrack().from(result));
 		}catch(e){
 			throw new SourceError.INTERNAL_ERROR(null, e);
@@ -200,11 +200,11 @@ const api = (new class SpotifyAPI{
 	async list_once(type, id, start = 0, length){
 		this.check_valid_id(id);
 
-		var playlist = new SpotifyPlaylist();
-		var images, tracks;
+		const playlist = new SpotifyPlaylist();
+		let images, tracks;
 
 		if(!start){
-			var list = await this.api_request(type + '/' + id);
+			const list = await this.api_request(type + '/' + id);
 
 			playlist.setMetadata(list.name, list.description);
 			images = list.images;
@@ -218,7 +218,7 @@ const api = (new class SpotifyAPI{
 		playlist.set(type, id);
 
 		try{
-			for(var item of tracks.items){
+			for(const item of tracks.items){
 				if(type == 'playlists' && item.track && !item.track.is_local)
 					playlist.push(new SpotifyTrack().from(item.track));
 				else if(type == 'albums'){
@@ -244,11 +244,11 @@ const api = (new class SpotifyAPI{
 	}
 
 	async list(type, id, limit){
-		var list = null;
-		var offset = 0;
+		let list = null;
+		let offset = 0;
 
 		do{
-			var result = await this.list_once(type, id, offset);
+			const result = await this.list_once(type, id, offset);
 
 			if(!list)
 				list = result;


### PR DESCRIPTION
Declaring variables with `var` is considered in javascript as deprecated and as a bad practice, since it can overwrite variables already declared in your code block. Use `const` or `let` instead.
You can read about this in an article like [Why don't we use var anymore?](https://medium.com/@codingsam/awesome-javascript-no-more-var-working-title-999428999994)

* Changed `var` statements to `const` & `let` statements
* Documentation updated