### PR TITLE
add platform discriminator

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -70,7 +70,6 @@ declare class TrackPlaylist extends TrackResults{
 }
 
 declare class Track{
-	platform: string;
 	playable: boolean;
 
 	author: string | null;
@@ -92,6 +91,7 @@ declare class Track{
 }
 
 declare class FileTrack extends Track{
+	platform: 'File';
 	isLocalFile: boolean;
 }
 
@@ -110,9 +110,41 @@ declare class FileSource{
 	resolve(url: string): FileTrack | null;
 }
 
+declare class YoutubeTrack extends Track {
+	platform: 'Youtube';
+}
+
+declare class YoutubePlaylist extends TrackPlaylist {
+	platform: 'Youtube';
+}
+
+declare class SoundcloudTrack extends Track{
+	platform: 'Soundcloud';
+}
+
+declare class SoundcloudPlaylist extends TrackPlaylist{
+	platform: 'Soundcloud';
+}
+
+declare class SpotifyTrack extends Track{
+	platform: 'Spotify';
+}
+
+declare class SpotifyPlaylist extends TrackPlaylist{
+	platform: 'Spotify';
+}
+
+declare class AppleMusicTrack extends Track{
+	platform: 'AppleMusic';
+}
+
+declare class AppleMusicPlaylist extends TrackPlaylist{
+	platform: 'AppleMusic';
+}
+
 declare class Source{
-	static resolve(input: string): Promise<Track | TrackPlaylist> | null;
-	static resolve(input: string, weak: boolean): Promise<Track | TrackPlaylist> | null;
+	static resolve(input: string): Promise<YoutubeTrack | YoutubePlaylist | SoundcloudTrack | SoundcloudPlaylist | SpotifyTrack | SpotifyPlaylist | AppleMusicTrack | AppleMusicPlaylist | null>;
+	static resolve(input: string, weak: boolean): Promise<YoutubeTrack | YoutubePlaylist | SoundcloudTrack | SoundcloudPlaylist | SpotifyTrack | SpotifyPlaylist | AppleMusicTrack | AppleMusicPlaylist | null>;
 	static Youtube: YoutubeSource;
 	static Soundcloud: APISource;
 	static Spotify: APISource;

--- a/index.d.ts
+++ b/index.d.ts
@@ -70,6 +70,7 @@ declare class TrackPlaylist extends TrackResults{
 }
 
 declare class Track{
+	platform: string;
 	playable: boolean;
 
 	author: string | null;

--- a/src/Source.js
+++ b/src/Source.js
@@ -322,7 +322,7 @@ const file = new class File extends APISource{
 }
 
 class Source{
-	static resolve(input, weak = true){
+	static async resolve(input, weak = true){
 		var sources = [youtube, soundcloud, spotify, apple];
 		var match = null;
 

--- a/src/api/AppleMusic.js
+++ b/src/api/AppleMusic.js
@@ -57,6 +57,7 @@ class AppleMusicResults extends TrackResults{
 }
 
 class AppleMusicPlaylist extends TrackPlaylist{
+	platform = 'AppleMusic';
 	set(type, id){
 		this.type = type;
 		this.id = id;

--- a/src/api/Soundcloud.js
+++ b/src/api/Soundcloud.js
@@ -100,6 +100,7 @@ class SoundcloudResults extends TrackResults{
 }
 
 class SoundcloudPlaylist extends TrackPlaylist{
+	platform = 'Soundcloud';
 	from(list){
 		this.permalink_url = list.permalink_url;
 		this.setMetadata(list.title, list.description);

--- a/src/api/Spotify.js
+++ b/src/api/Spotify.js
@@ -45,6 +45,7 @@ class SpotifyResults extends TrackResults{
 }
 
 class SpotifyPlaylist extends TrackPlaylist{
+	platform = 'Spotify';
 	set(type, id){
 		this.type = type;
 		this.id = id;

--- a/src/api/Youtube.js
+++ b/src/api/Youtube.js
@@ -171,6 +171,7 @@ class YoutubeResults extends TrackResults{
 }
 
 class YoutubePlaylist extends TrackPlaylist{
+	platform = 'Youtube';
 	process(id, data, offset){
 		this.id = id;
 


### PR DESCRIPTION
Fixed the return type of `Source.resolve` (always returns a promise)
```diff
- static resolve(input: string): Promise<Track | TrackPlaylist> | null;
+ static resolve(input: string): Promise<Track | TrackPlaylist | null>;
- static resolve(input: string, weak: boolean): Promise<Track | TrackPlaylist> | null;
+ static resolve(input: string, weak: boolean): Promise<Track | TrackPlaylist | null>;
```
further specifies the return of `Source.resolve`
```ts
static resolve(input: string): Promise<YoutubeTrack | YoutubePlaylist | SoundcloudTrack | SoundcloudPlaylist | SpotifyTrack | SpotifyPlaylist | AppleMusicTrack | AppleMusicPlaylist | null>;
static resolve(input: string, weak: boolean): Promise<YoutubeTrack | YoutubePlaylist | SoundcloudTrack | SoundcloudPlaylist | SpotifyTrack | SpotifyPlaylist | AppleMusicTrack | AppleMusicPlaylist | null>;
```
All api classes extending from `Track` and `TrackPlaylist` have been declared a `platform` property for their discrimination

example:
```ts
import yasha from 'yasha'

asunc function doYoutubeThings(input: string) {
    const resolved = await yasha.Source.resolve(input)
    // resolved is any platform possible
    if (resolved.platform !== 'Youtube') throw new Error('Not a Youtube track')
    // resolved is YoutubeTrack or YoutubePlaylist
    // do youtube things ...
}
```